### PR TITLE
Add voteScore, fix documentation, make read-only methods virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@
   comment.voteScore;          // 0
   comment.upvote(user);
   comment.voteScore;          // 1
-  comment.downvote(user);
-  comment.voteScore;          // 0
   comment.downvote(user2);
+  comment.voteScore;          // 0
+  comment.downvote(user3);
   comment.voteScore;          // -1
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@
   });
 ```
 
+### .unvote(user)
+  Retracts vote on document by user. `user` can be either a model instance (like `User`), an `ObjectId` or even the hex string from `ObjectId`.
+```js
+  comment.upvote(author);
+  comment.voted(author);    // true
+  comment.unvote(author);
+  comment.voted(author);    // false
+```
+
+### .unvote(user, fn)
+  Same as `.uvote(user)` but calls `save` on model with `fn` function as callback.
+```js
+  comment.unvote(author, function(err, doc) {
+    doc.voted(author);      // false
+    doc.downvoted(author);  // false
+    doc.upvoted(author);    // false
+  });
+```
+
 ### .upvoted(user)
   Returns `true` if document was 'upvoted' by user. `false` otherwise.
 ```js
@@ -102,33 +121,45 @@
   comment.voted(user);    // true
 ```
 
-### .upvotes()
+### .upvotes
   Returns Number of `upvotes` count.
 ```js
   comment.downvote(user);
-  comment.upvotes();      // 0
+  comment.upvotes;      // 0
   comment.upvote(user);
-  comment.upvotes();      // 1
+  comment.upvotes;      // 1
 ```
 
-### .downvotes()
+### .downvotes
   Returns Number of `downvotes` count.
 ```js
   comment.downvote(user);
-  comment.upvotes();      // 1
+  comment.downvotes;      // 1
   comment.upvote(user);
-  comment.upvotes();      // 0
+  comment.downvotes;      // 0
 ```
 
-### .votes()
-  Returns Number of `votes` count.
+### .votes
+  Returns Number of unique `votes` count.
 ```js
   comment.downvote(user);
-  comment.votes();          // 1
+  comment.votes;          // 1
   comment.upvote(user);
-  comment.votes();          // 1
+  comment.votes;          // 1
   comment.downvote(user2);
-  comment.votes();          // 2
+  comment.votes;          // 2
+```
+
+### .voteScore
+  Returns Number of `upvotes` count minus the number of `downvotes` count.
+```js
+  comment.voteScore;          // 0
+  comment.upvote(user);
+  comment.voteScore;          // 1
+  comment.downvote(user);
+  comment.voteScore;          // 0
+  comment.downvote(user2);
+  comment.voteScore;          // -1
 ```
 
 ## Test

--- a/index.js
+++ b/index.js
@@ -91,18 +91,22 @@ function voting (schema, options) {
     return schema.methods.upvoted(user) || schema.methods.downvoted(user);
   }
 
-  schema.methods.upvotes = function upvotes() {
+  schema.virtual('upvotes').get(function upvotes() {
     return this.vote.positive.length;
-  }
+  });
 
-  schema.methods.downvotes = function upvotes() {
+  schema.virtual('downvotes').get(function downvotes() {
     return this.vote.negative.length;
-  }
+  });
 
-  schema.methods.votes = function upvotes() {
+  schema.virtual('votes').get(function votes() {
     var positives = this.vote.positive;
     var negatives = this.vote.negative;
     return [].concat(positives).concat(negatives).length;
-  }
+  });
+  
+  schema.virtual('voteScore').get(function voteScore() {
+    return this.upvotes - this.downvotes;
+  });
 
 }

--- a/test/index.js
+++ b/test/index.js
@@ -181,7 +181,7 @@ describe('voting', function () {
 
   });
 
-  describe.only('unvote', function() {
+  describe('unvote', function() {
     it('should unvote', function(done) {
       var author2 = new User({ name: 'Jorge' });
 
@@ -264,13 +264,13 @@ describe('voting', function () {
       var author2 = new User({ name: 'Jorge' });
 
       comment.downvote(author);
-      assert.equal(0, comment.upvotes());
+      assert.equal(0, comment.upvotes);
 
       comment.upvote(author2);
-      assert.equal(1, comment.upvotes());
+      assert.equal(1, comment.upvotes);
 
       comment.upvote(author);
-      assert.equal(2, comment.upvotes());
+      assert.equal(2, comment.upvotes);
 
       done();
     });
@@ -281,13 +281,13 @@ describe('voting', function () {
       var author2 = new User({ name: 'Jorge' });
 
       comment.upvote(author);
-      assert.equal(0, comment.downvotes());
+      assert.equal(0, comment.downvotes);
 
       comment.downvote(author2);
-      assert.equal(1, comment.downvotes());
+      assert.equal(1, comment.downvotes);
 
       comment.downvote(author);
-      assert.equal(2, comment.downvotes());
+      assert.equal(2, comment.downvotes);
 
       done();
     });
@@ -298,13 +298,30 @@ describe('voting', function () {
       var author2 = new User({ name: 'Jorge' });
 
       comment.upvote(author);
-      assert.equal(1, comment.votes());
+      assert.equal(1, comment.votes);
 
       comment.downvote(author2);
-      assert.equal(2, comment.votes());
+      assert.equal(2, comment.votes);
 
       comment.downvote(author);
-      assert.equal(2, comment.votes());
+      assert.equal(2, comment.votes);
+
+      done();
+    });
+  });
+  
+  describe('voteScore', function() {
+    it('should calculate the correct score', function(done) {
+      var author2 = new User({ name: 'Jorge' });
+
+      comment.upvote(author);
+      assert.equal(1, comment.voteScore);
+
+      comment.downvote(author2);
+      assert.equal(0, comment.voteScore);
+
+      comment.downvote(author);
+      assert.equal(-2, comment.voteScore);
 
       done();
     });


### PR DESCRIPTION
- Addresses issue #5 (vote scores)
- Adds documentation for the `.unvote()` method (which I did not know exists until I examined the source code)
- Switches the methods which just return a count to be [virtual getters](http://mongoosejs.com/docs/guide.html)
  - Provides a nicer syntax. Ex: `comment.upvotes` instead of `comment.upvotes()`
- Updated tests accordingly
